### PR TITLE
Vendor folder ignonore

### DIFF
--- a/src/modules/Zikula/ContentModule/.gitignore
+++ b/src/modules/Zikula/ContentModule/.gitignore
@@ -1,1 +1,1 @@
-vendor/
+./vendor/


### PR DESCRIPTION
With this new syntax vendor folder in Content
src/modules/Zikula/ContentModule/resources/public/js/vendor wont be infored anymore.

This was causing issue when module is loaded in the cms via git clone. It was causing error of missing assests that are coming from this vendor folder in administration panel.

This was found in Zikula 2.0.13, Content module 5.1